### PR TITLE
Hide timestamp on smaller screens

### DIFF
--- a/web/mamirc.css
+++ b/web/mamirc.css
@@ -362,6 +362,13 @@ body.hide {  /* For log out */
 	color: #A0A0A0;
 }
 
+/* Hide timestamp on tiny screens (like iPhone 4/5) */
+@media only screen and (max-width: 500px) { 
+	#message-list td:nth-child(1) {
+  		display:none; 
+	}
+}
+
 #message-list td:nth-child(3) {  /* User text */
 	width: 98%;
 	text-align: left;


### PR DESCRIPTION
To save screen space on tiny phones

Note: A minimum of 320px will still work for iPhone 4/5 (but not 6). Not sure about Android sizes but I don't think any of them are that tiny... lol

(A better solution might be to actually reconfigure the table and/or convert it into <divs> and <floats>, but that's a lot more work.)
